### PR TITLE
benches: don't include regex compilation in search benchmarks

### DIFF
--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,8 +1,8 @@
-use std::hint::black_box;
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use once_cell::sync::Lazy;
 use regex;
 use rzozowski;
-use once_cell::sync::Lazy;
+use std::hint::black_box;
 
 struct TestPattern {
     name: &'static str,
@@ -11,92 +11,94 @@ struct TestPattern {
     invalid_string: String,
 }
 
-static TEST_PATTERNS: Lazy<[TestPattern; 14]> = Lazy::new(|| [
-    TestPattern {
-        name: "concatenation",
-        pattern: "abcdef",
-        valid_string: "abcdef".to_string(),
-        invalid_string: "abcde".to_string(),
-    },
-    TestPattern {
-        name: "alternation",
-        pattern: "a|b",
-        valid_string: "a".to_string(),
-        invalid_string: "c".to_string(),
-    },
-    TestPattern {
-        name: "star",
-        pattern: "a*",
-        valid_string: "aaaa".to_string(),
-        invalid_string: "b".to_string(),
-    },
-    TestPattern {
-        name: "plus",
-        pattern: "a+",
-        valid_string: "aaaa".to_string(),
-        invalid_string: "".to_string(),
-    },
-    TestPattern {
-        name: "question",
-        pattern: "a?",
-        valid_string: "a".to_string(),
-        invalid_string: "b".to_string(),
-    },
-    TestPattern {
-        name: "class",
-        pattern: "[a-z]",
-        valid_string: "j".to_string(),
-        invalid_string: "1".to_string(),
-    },
-    TestPattern {
-        name: "special_char_sequences",
-        pattern: r"\d\w",
-        valid_string: "1_".to_string(),
-        invalid_string: "a_".to_string(),
-    },
-    TestPattern {
-        name: "count",
-        pattern: "a{2,270}",
-        valid_string: "a".repeat(269),
-        invalid_string: "a".repeat(271),
-    },
-    TestPattern {
-        name: "nested_star",
-        pattern: "(a*b*c*)*d+",
-        valid_string: "aaabbabbacacbacbcadddd".to_string(),
-        invalid_string: "abcabcabccccc".to_string(),
-    },
-    TestPattern {
-        name: "deep_nesting",
-        pattern: "((a|b|c)(d|e|f)(g|h|i))+",
-        valid_string: "adgbdhceia".to_string(),
-        invalid_string: "adgbdhceid".to_string(),
-    },
-    TestPattern {
-        name: "complex_count",
-        pattern: "(a{2,5}b{3,7}c{1,9}){2,4}",
-        valid_string: "aaabbbcaabbbbbbccaaaaabbbcc".to_string(),
-        invalid_string: "aaabbbcaabbbbbbccaaaaabbbccaaaaaa".to_string(),
-    },
-    TestPattern {
-        name: "complex_class",
-        pattern: r"[a-zA-Z0-9_][a-z]{5,10}\d{3,6}",
-        valid_string: "7knmavpp1234".to_string(),
-        invalid_string: "_abcde12".to_string(),
-    },
-    TestPattern {
-        name: "exponential_plus",
-        pattern: "(a+)+b",
-        valid_string: "aaaaaaaaaaab".to_string(),
-        invalid_string: "aaaaaaaaaa".to_string(),
-    },
-    TestPattern {
-        name: "email",
-        pattern: r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z][a-zA-Z]+",
-        valid_string: "test@example.com".to_string(),
-        invalid_string: "test@example".to_string(),
-    },
-]);
+static TEST_PATTERNS: Lazy<[TestPattern; 14]> = Lazy::new(|| {
+    [
+        TestPattern {
+            name: "concatenation",
+            pattern: "abcdef",
+            valid_string: "abcdef".to_string(),
+            invalid_string: "abcde".to_string(),
+        },
+        TestPattern {
+            name: "alternation",
+            pattern: "a|b",
+            valid_string: "a".to_string(),
+            invalid_string: "c".to_string(),
+        },
+        TestPattern {
+            name: "star",
+            pattern: "a*",
+            valid_string: "aaaa".to_string(),
+            invalid_string: "b".to_string(),
+        },
+        TestPattern {
+            name: "plus",
+            pattern: "a+",
+            valid_string: "aaaa".to_string(),
+            invalid_string: "".to_string(),
+        },
+        TestPattern {
+            name: "question",
+            pattern: "a?",
+            valid_string: "a".to_string(),
+            invalid_string: "b".to_string(),
+        },
+        TestPattern {
+            name: "class",
+            pattern: "[a-z]",
+            valid_string: "j".to_string(),
+            invalid_string: "1".to_string(),
+        },
+        TestPattern {
+            name: "special_char_sequences",
+            pattern: r"\d\w",
+            valid_string: "1_".to_string(),
+            invalid_string: "a_".to_string(),
+        },
+        TestPattern {
+            name: "count",
+            pattern: "a{2,270}",
+            valid_string: "a".repeat(269),
+            invalid_string: "a".repeat(271),
+        },
+        TestPattern {
+            name: "nested_star",
+            pattern: "(a*b*c*)*d+",
+            valid_string: "aaabbabbacacbacbcadddd".to_string(),
+            invalid_string: "abcabcabccccc".to_string(),
+        },
+        TestPattern {
+            name: "deep_nesting",
+            pattern: "((a|b|c)(d|e|f)(g|h|i))+",
+            valid_string: "adgbdhceia".to_string(),
+            invalid_string: "adgbdhceid".to_string(),
+        },
+        TestPattern {
+            name: "complex_count",
+            pattern: "(a{2,5}b{3,7}c{1,9}){2,4}",
+            valid_string: "aaabbbcaabbbbbbccaaaaabbbcc".to_string(),
+            invalid_string: "aaabbbcaabbbbbbccaaaaabbbccaaaaaa".to_string(),
+        },
+        TestPattern {
+            name: "complex_class",
+            pattern: r"[a-zA-Z0-9_][a-z]{5,10}\d{3,6}",
+            valid_string: "7knmavpp1234".to_string(),
+            invalid_string: "_abcde12".to_string(),
+        },
+        TestPattern {
+            name: "exponential_plus",
+            pattern: "(a+)+b",
+            valid_string: "aaaaaaaaaaab".to_string(),
+            invalid_string: "aaaaaaaaaa".to_string(),
+        },
+        TestPattern {
+            name: "email",
+            pattern: r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z][a-zA-Z]+",
+            valid_string: "test@example.com".to_string(),
+            invalid_string: "test@example".to_string(),
+        },
+    ]
+});
 
 fn bench_regex_parse(c: &mut Criterion) {
     let mut group = c.benchmark_group("regex_parse");
@@ -105,13 +107,17 @@ fn bench_regex_parse(c: &mut Criterion) {
         group.bench_with_input(
             BenchmarkId::new("rzozowski", pattern.name),
             pattern.pattern,
-            |b, pat| b.iter(|| black_box(match rzozowski::Regex::new(pat) {
-                Ok(re) => re,
-                Err(e) => {
-                    eprintln!("Pattern: {pat}");
-                    panic!("{e}");
-                }
-            })),
+            |b, pat| {
+                b.iter(|| {
+                    black_box(match rzozowski::Regex::new(pat) {
+                        Ok(re) => re,
+                        Err(e) => {
+                            eprintln!("Pattern: {pat}");
+                            panic!("{e}");
+                        }
+                    })
+                })
+            },
         );
 
         group.bench_with_input(
@@ -128,41 +134,29 @@ fn bench_regex_matches(c: &mut Criterion) {
     let mut group = c.benchmark_group("regex_matches");
 
     for pattern in TEST_PATTERNS.iter() {
-        group.bench_with_input(
-            BenchmarkId::new("rzozowski-valid", pattern.name),
-            pattern.pattern,
-            |b, pat| b.iter(|| {
-                let re = rzozowski::Regex::new(pat).unwrap();
+        let re = rzozowski::Regex::new(pattern.pattern).unwrap();
+        group.bench_function(BenchmarkId::new("rzozowski-valid", pattern.name), |b| {
+            b.iter(|| {
                 black_box(re.matches(&pattern.valid_string));
-            }),
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("rzozowski-invalid", pattern.name),
-            pattern.pattern,
-            |b, pat| b.iter(|| {
-                let re = rzozowski::Regex::new(pat).unwrap();
+            })
+        });
+        group.bench_function(BenchmarkId::new("rzozowski-invalid", pattern.name), |b| {
+            b.iter(|| {
                 black_box(re.matches(&pattern.invalid_string));
-            }),
-        );
+            })
+        });
 
-        group.bench_with_input(
-            BenchmarkId::new("regex-valid", pattern.name),
-            pattern.pattern,
-            |b, pat| b.iter(|| {
-                let re = regex::Regex::new(pat).unwrap();
+        let re = regex::Regex::new(pattern.pattern).unwrap();
+        group.bench_function(BenchmarkId::new("regex-valid", pattern.name), |b| {
+            b.iter(|| {
                 black_box(re.is_match(&pattern.valid_string));
-            }),
-        );
-
-        group.bench_with_input(
-            BenchmarkId::new("regex-invalid", pattern.name),
-            pattern.pattern,
-            |b, pat| b.iter(|| {
-                let re = regex::Regex::new(pat).unwrap();
+            })
+        });
+        group.bench_function(BenchmarkId::new("regex-invalid", pattern.name), |b| {
+            b.iter(|| {
                 black_box(re.is_match(&pattern.invalid_string));
-            }),
-        );
+            })
+        });
     }
 
     group.finish();


### PR DESCRIPTION
While measuring regex compilation time is a fair and valid thing to do,
this is captured by the "parse" benchmarks. Including regex compilation
time in the *search* benchmarks is very odd, and especially so when
there are zero benchmarks that don't include regex compilation. In most
cases, a regex is compiled once and reused many times.

For more careful and rigorous benchmarking, I would encourage you to
submit your regex engine to
[rebar](https://github.com/BurntSushi/rebar). Although, in order for
that to work, you regex engine has to be able to at least count the
total number of matches in a haystack.

Nevertheless, this patch fixes the search benchmarks so that regex
compilation is not part of them. This *dramatically* changes the
conclusions you can draw in terms of the relative speed from the regex
crate:

```
group                             new/regex_matches/regex-               new/regex_matches/rzozowski-
-----                             ------------------------               ----------------------------
invalid/alternation               1.00      5.4±0.02ns        ? ?/sec    9.55     52.0±0.71ns        ? ?/sec
invalid/class                     1.00     10.0±0.04ns        ? ?/sec    1.62     16.2±0.26ns        ? ?/sec
invalid/complex_class             1.00      1.5±0.02ns        ? ?/sec    2346.84     3.6±0.02µs        ? ?/sec
invalid/complex_count             1.00     24.3±0.29ns        ? ?/sec    3096.18    75.2±0.29µs        ? ?/sec
invalid/concatenation             1.00      1.5±0.01ns        ? ?/sec    2071.63     3.2±0.03µs        ? ?/sec
invalid/count                     1.00     15.0±0.08ns        ? ?/sec    942.10    14.2±0.20µs        ? ?/sec
invalid/deep_nesting              1.00     26.3±0.12ns        ? ?/sec    1823.48    48.0±0.56µs        ? ?/sec
invalid/email                     1.00     31.4±0.43ns        ? ?/sec    1537.34    48.2±0.13µs        ? ?/sec
invalid/exponential_plus          1.00     15.8±0.16ns        ? ?/sec    1112.41    17.6±0.12µs        ? ?/sec
invalid/nested_star               1.00      9.4±0.11ns        ? ?/sec    7390.43    69.3±0.31µs        ? ?/sec
invalid/plus                      1.00      1.5±0.01ns        ? ?/sec    8.91     13.8±0.21ns        ? ?/sec
invalid/question                  1.00     12.2±0.05ns        ? ?/sec    5.34     64.9±1.31ns        ? ?/sec
invalid/special_char_sequences    1.00     10.6±0.13ns        ? ?/sec    22.07   234.2±2.65ns        ? ?/sec
invalid/star                      1.00     12.2±0.06ns        ? ?/sec    7.22     87.8±1.61ns        ? ?/sec
valid/alternation                 1.00      8.3±0.05ns        ? ?/sec    6.67     55.4±0.81ns        ? ?/sec
valid/class                       1.00     10.3±0.11ns        ? ?/sec    1.25     12.9±0.19ns        ? ?/sec
valid/complex_class               1.00     13.0±0.17ns        ? ?/sec    360.38     4.7±0.02µs        ? ?/sec
valid/complex_count               1.00     24.7±0.25ns        ? ?/sec    2807.28    69.2±0.69µs        ? ?/sec
valid/concatenation               1.00      9.7±0.13ns        ? ?/sec    331.15     3.2±0.04µs        ? ?/sec
valid/count                       1.00     15.0±0.07ns        ? ?/sec    934.62    14.0±0.21µs        ? ?/sec
valid/deep_nesting                1.00     26.3±0.11ns        ? ?/sec    1827.02    48.1±0.17µs        ? ?/sec
valid/email                       1.00     32.5±0.49ns        ? ?/sec    1885.24    61.3±0.22µs        ? ?/sec
valid/exponential_plus            1.00     18.4±0.13ns        ? ?/sec    1082.37    19.9±0.19µs        ? ?/sec
valid/nested_star                 1.00     52.5±0.56ns        ? ?/sec    2020.59   106.2±1.04µs        ? ?/sec
valid/plus                        1.00     13.6±0.10ns        ? ?/sec    46.03   627.2±5.71ns        ? ?/sec
valid/question                    1.00     12.2±0.05ns        ? ?/sec    5.47     66.6±1.00ns        ? ?/sec
valid/special_char_sequences      1.00     10.8±0.05ns        ? ?/sec    23.15   249.8±3.86ns        ? ?/sec
valid/star                        1.00     12.2±0.05ns        ? ?/sec    25.96   315.6±3.78ns        ? ?/sec
```
