### PR TITLE
More clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -516,7 +516,6 @@ dependencies = [
  "chumsky",
  "criterion",
  "logos",
- "once_cell",
  "regex",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ documentation = "https://docs.rs/rzozowski"
 readme = "README.md"
 keywords = ["regex", "brzozowski", "derivatives"]
 categories = ["text-processing"]
+rust-version = "1.80"
 
 [lib]
 name = "rzozowski"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ name = "rzozowski"
 [dependencies]
 chumsky = "0.10.1"
 logos = "0.15.0"
-once_cell = "1.19.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }

--- a/benches/benchmark.rs
+++ b/benches/benchmark.rs
@@ -1,8 +1,7 @@
 use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
-use once_cell::sync::Lazy;
 use regex;
 use rzozowski;
-use std::hint::black_box;
+use std::{hint::black_box, sync::LazyLock};
 
 struct TestPattern {
     name: &'static str,
@@ -11,7 +10,7 @@ struct TestPattern {
     invalid_string: String,
 }
 
-static TEST_PATTERNS: Lazy<[TestPattern; 14]> = Lazy::new(|| {
+static TEST_PATTERNS: LazyLock<[TestPattern; 14]> = LazyLock::new(|| {
     [
         TestPattern {
             name: "concatenation",

--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -99,7 +99,7 @@ impl Display for Regex {
             Regex::ZeroOrMore(inner) => format!("({inner})*"),
             Regex::OneOrMore(inner) => format!("({inner})+"),
             Regex::Class(ranges) => {
-                let ranges_str = ranges.iter().map(|range| range.to_string()).collect::<Vec<String>>().join("");
+                let ranges_str = ranges.iter().map(|range| range.to_string()).collect::<String>();
                 format!("[{ranges_str}]")
             }
             Regex::Count(inner, quantifier) => {

--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -37,10 +37,10 @@ impl Display for CharRange {
 
 impl CharRange {
     /// Returns `true` if the given character is in the range, otherwise returns `false`.
-    fn contains(&self, c: &char) -> bool {
+    fn contains(&self, c: char) -> bool {
         match self {
-            CharRange::Single(ch) => *ch == *c,
-            CharRange::Range(start, end) => *start <= *c && *c <= *end,
+            CharRange::Single(ch) => *ch == c,
+            CharRange::Range(start, end) => *start <= c && c <= *end,
         }
     }
 }
@@ -188,7 +188,7 @@ impl Regex {
             },
             Regex::Class(ranges) => {
                 for range in ranges {
-                    if range.contains(&c) {
+                    if range.contains(c) {
                         return Regex::Epsilon;
                     }
                 }
@@ -371,6 +371,7 @@ impl Regex {
 }
 
 mod tests {
+    #[allow(unused_imports)]
     use super::*;
 
     // comprehensive derivative tests

--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -12,7 +12,7 @@ fn escape_regex_char(c: char, in_class: bool) -> String {
     };
 
     if to_escape.contains(&c) {
-        format!("\\{}", c)
+        format!("\\{c}")
     } else {
         c.to_string()
     }
@@ -93,17 +93,17 @@ impl Display for Regex {
             Regex::Empty => "∅".to_string(),
             Regex::Epsilon => "ε".to_string(),
             Regex::Literal(c) => escape_regex_char(*c, false),
-            Regex::Concat(left, right) => format!("{}{}", left, right),
-            Regex::Or(left, right) => format!("({}|{})", left, right),
-            Regex::ZeroOrOne(inner) => format!("({})?", inner),
-            Regex::ZeroOrMore(inner) => format!("({})*", inner),
-            Regex::OneOrMore(inner) => format!("({})+", inner),
+            Regex::Concat(left, right) => format!("{left}{right}"),
+            Regex::Or(left, right) => format!("({left}|{right})"),
+            Regex::ZeroOrOne(inner) => format!("({inner})?"),
+            Regex::ZeroOrMore(inner) => format!("({inner})*"),
+            Regex::OneOrMore(inner) => format!("({inner})+"),
             Regex::Class(ranges) => {
                 let ranges_str = ranges.iter().map(|range| range.to_string()).collect::<Vec<String>>().join("");
-                format!("[{}]", ranges_str)
+                format!("[{ranges_str}]")
             }
             Regex::Count(inner, quantifier) => {
-                format!("({}){}", inner, quantifier)
+                format!("({inner}){quantifier}")
             },
         })
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,19 @@
 
 //! *rzozowski* (ruh-zov-ski) is a Rust crate for reasoning about regular expressions in terms of Brzozowski derivatives.
 
+#![warn(
+    clippy::suspicious,
+    clippy::complexity,
+    clippy::perf,
+    clippy::style,
+    clippy::uninlined_format_args,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::unnecessary_join,
+    clippy::unnecessary_wraps,
+    clippy::format_push_string,
+    clippy::non_std_lazy_statics
+)]
+
 mod derivatives;
 mod parser;
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -6,9 +6,8 @@ use chumsky::{
 };
 use lexer::Token;
 use logos::Logos;
-use std::collections::HashMap;
+use std::{collections::HashMap, sync::LazyLock};
 use std::fmt::Write as _;
-use once_cell::sync::Lazy;
 
 /// Represents a regex in a more convenient format for parsing. This is an intermediate representation before converting to the final `Regex` type.
 #[derive(Clone)]
@@ -48,7 +47,7 @@ impl RegexRepresentation {
 }
 
 /// A map of special character sequences to their corresponding `RegexRepresentation`. For example, `\d` maps to `[0-9]`.
-static SPECIAL_CHAR_SEQUENCES: Lazy<HashMap<char, RegexRepresentation>> = Lazy::new(|| {
+static SPECIAL_CHAR_SEQUENCES: LazyLock<HashMap<char, RegexRepresentation>> = LazyLock::new(|| {
     let mut map = HashMap::new();
 
     // "\d" => [0-9]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -7,6 +7,7 @@ use chumsky::{
 use lexer::Token;
 use logos::Logos;
 use std::collections::HashMap;
+use std::fmt::Write as _;
 use once_cell::sync::Lazy;
 
 /// Represents a regex in a more convenient format for parsing. This is an intermediate representation before converting to the final `Regex` type.
@@ -359,12 +360,13 @@ pub fn parse_string_to_regex(input: &str) -> Result<Regex, String> {
                 let found = error.found().map(|t| t.to_string()).unwrap_or_else(|| "end of input".to_string());
                 let expected = error.expected().map(|t| t.to_string()).collect::<Vec<_>>();
 
-                error_message.push_str(&format!(
-                    "Error at position {}: found {}, expected one of: {}\n",
+                let _ = writeln!(
+                    error_message,
+                    "Error at position {}: found {}, expected one of: {}",
                     span.start,
                     found,
                     expected.join(", ")
-                ));
+                );
             }
 
             Err(error_message)

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -83,11 +83,11 @@ where
         matches!(token, Token::At)
     })
     .filter(|token| {
-        let c = token.as_char().unwrap();
+        let c = token.as_char();
         !NON_CLASS_ESCAPE_CHARS.contains(&c)
     })
     .map(|token| {
-        token.as_char().unwrap()
+        token.as_char()
     })
 }
 
@@ -99,11 +99,11 @@ where
     just(Token::Backslash)
         .then(any())
         .filter(|(_, token): &(_, Token)| {
-            let c = token.as_char().unwrap();
+            let c = token.as_char();
             NON_CLASS_ESCAPE_CHARS.contains(&c)
         })
         .map(|(_, token)| {
-            token.as_char().unwrap()
+            token.as_char()
         })
 }
 
@@ -115,11 +115,11 @@ where
     just(Token::Backslash)
         .then(any().filter(|token| matches!(token, Token::Literal(_))))
         .filter(|(_, token)| {
-            let c = token.as_char().unwrap();
+            let c = token.as_char();
             SPECIAL_CHAR_SEQUENCES.contains_key(&c)
         })
         .map(|(_, token)| {
-            let c = token.as_char().unwrap();
+            let c = token.as_char();
             SPECIAL_CHAR_SEQUENCES[&c].clone()
         })
 }
@@ -146,9 +146,9 @@ where
         matches!(token, Token::Dot) ||
         matches!(token, Token::At)
     })
-    .filter(|token| !CLASS_ESCAPE_CHARS.contains(&token.as_char().unwrap()))
+    .filter(|token| !CLASS_ESCAPE_CHARS.contains(&token.as_char()))
     .map(|token| {
-        token.as_char().unwrap()
+        token.as_char()
     })
 }
 
@@ -160,11 +160,11 @@ where
     just(Token::Backslash)
         .then(any())
         .filter(|(_, token): &(_, Token)| {
-            let c = token.as_char().unwrap();
+            let c = token.as_char();
             CLASS_ESCAPE_CHARS.contains(&c)
         })
         .map(|(_, token)| {
-            token.as_char().unwrap()
+            token.as_char()
         })
 }
 
@@ -236,11 +236,11 @@ where
 {
     any().filter(|token| matches!(token, Token::Literal(_)))
         .filter(|token| {
-            let c = token.as_char().unwrap();
+            let c = token.as_char();
             c.is_ascii_digit()
         })
         .map(|token| {
-            token.as_char().unwrap()
+            token.as_char()
         })
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -325,6 +325,7 @@ where
                 }).unwrap()
             });
 
+        #[allow(clippy::let_and_return)]
         let alternation = concatenation.separated_by(just(Token::Pipe))
             .at_least(1)
             .collect::<Vec<_>>()

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -46,25 +46,25 @@ impl fmt::Display for Token {
 }
 
 impl Token {
-    pub fn as_char(&self) -> Result<char, ()> {
+    pub fn as_char(&self) -> char {
         match self {
-            Token::Literal(c) => Ok(*c),
-            Token::OpenParen => Ok('('),
-            Token::CloseParen => Ok(')'),
-            Token::OpenCurly => Ok('{'),
-            Token::CloseCurly => Ok('}'),
-            Token::OpenBracket => Ok('['),
-            Token::CloseBracket => Ok(']'),
-            Token::Pipe => Ok('|'),
-            Token::Star => Ok('*'),
-            Token::Plus => Ok('+'),
-            Token::Question => Ok('?'),
-            Token::Hyphen => Ok('-'),
-            Token::Backslash => Ok('\\'),
-            Token::Comma => Ok(','),
-            Token::Percent => Ok('%'),
-            Token::Dot => Ok('.'),
-            Token::At => Ok('@'),
+            Token::Literal(c) => *c,
+            Token::OpenParen => '(',
+            Token::CloseParen => ')',
+            Token::OpenCurly => '{',
+            Token::CloseCurly => '}',
+            Token::OpenBracket => '[',
+            Token::CloseBracket => ']',
+            Token::Pipe => '|',
+            Token::Star => '*',
+            Token::Plus => '+',
+            Token::Question => '?',
+            Token::Hyphen => '-',
+            Token::Backslash => '\\',
+            Token::Comma => ',',
+            Token::Percent => '%',
+            Token::Dot => '.',
+            Token::At => '@',
         }
     }
 }

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -41,7 +41,7 @@ pub enum Token {
 
 impl fmt::Display for Token {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "{self:?}")
     }
 }
 


### PR DESCRIPTION
**Note:** this PR leads to the MSRV increasing from 1.74 to 1.80, which I've set in Cargo.toml.
Just let me know if the MSRV change (or any other part of the PR) isn't desirable and I'll remove the corresponding commit.

Specifically, I've enabled the following lints/lint groups and fixed any warnings that were triggered:
- [clippy::suspicious](https://rust-lang.github.io/rust-clippy/master/?groups=suspicious) (group)
- [clippy::complexity](https://rust-lang.github.io/rust-clippy/master/?groups=complexity) (group)
- [clippy::perf](https://rust-lang.github.io/rust-clippy/master/?groups=perf) (group)
- [clippy::style](https://rust-lang.github.io/rust-clippy/master/?groups=style) (group)
- [clippy::uninlined_format_args](https://rust-lang.github.io/rust-clippy/master/#uninlined_format_args)
- [clippy::trivially_copy_pass_by_ref](https://rust-lang.github.io/rust-clippy/master/#trivially_copy_pass_by_ref)
- [clippy::unnecessary_join](https://rust-lang.github.io/rust-clippy/master/#unnecessary_join)
- [clippy::unnecessary_wraps](https://rust-lang.github.io/rust-clippy/master/#unnecessary_wraps)
- [clippy::format_push_string](https://rust-lang.github.io/rust-clippy/master/#format_push_string)
- [clippy::non_std_lazy_statics](https://rust-lang.github.io/rust-clippy/master/#non_std_lazy_statics)

Fixing `clippy::non_std_lazy_statics` also lets us remove the dependency on the `once_cell` crate, as the type `once_cell::sync::Lazy` has been superseded by `std::sync::LazyLock`. (This is the change that causes the increased MSRV)

