### PR TITLE
WIP: Lint refactoring. (don't merge yet)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,10 +24,54 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
 name = "anstyle"
 version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
 
 [[package]]
 name = "autocfg"
@@ -116,6 +160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2df961d8c8a0d08aa9945718ccf584145eee3f3aa06cddbeac12933781102e04"
 dependencies = [
  "clap_builder",
+ "clap_derive",
 ]
 
 [[package]]
@@ -124,8 +169,22 @@ version = "4.5.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "132dbda40fb6753878316a489d5a1242a8ef2f0d9e47ba01c951ea8aa7d013a5"
 dependencies = [
+ "anstream",
  "anstyle",
  "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -133,6 +192,12 @@ name = "clap_lex"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "criterion"
@@ -247,10 +312,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbd780fe5cc30f81464441920d82ac8740e2e46b29a6fad543ddd075229ce37e"
+
+[[package]]
+name = "indexmap"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+dependencies = [
+ "equivalent",
+ "hashbrown",
+]
 
 [[package]]
 name = "is-terminal"
@@ -262,6 +343,12 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -345,6 +432,17 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "monk"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672a465ae4fee10cc67c29c46c879d08811451350daab254ae51d7cafe83b8d"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_yaml",
+]
 
 [[package]]
 name = "num-traits"
@@ -516,6 +614,7 @@ dependencies = [
  "chumsky",
  "criterion",
  "logos",
+ "monk",
  "regex",
 ]
 
@@ -567,6 +666,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,6 +696,12 @@ dependencies = [
  "psm",
  "windows-sys",
 ]
+
+[[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
@@ -617,6 +735,18 @@ name = "unicode-segmentation"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,6 @@ regex = "1.11.1"
 [[bench]]
 name = "benchmark"
 harness = false
+
+[build-dependencies]
+monk = "0.2.1"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,3 @@
+pub fn main() {
+    monk::init();
+}

--- a/monk.yaml
+++ b/monk.yaml
@@ -1,0 +1,8 @@
+pre-commit:
+  commands:
+    - cargo fmt -- --check
+    - cargo clippy -- -D warnings
+
+pre-push:
+  commands:
+    - cargo test

--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -38,7 +38,7 @@ impl Display for CharRange {
 
 impl CharRange {
     /// Returns `true` if the given character is in the range, otherwise returns `false`.
-    fn contains(&self, c: char) -> bool {
+    const fn contains(&self, c: char) -> bool {
         match self {
             Self::Single(ch) => *ch == c,
             Self::Range(start, end) => *start <= c && c <= *end,

--- a/src/derivatives.rs
+++ b/src/derivatives.rs
@@ -1,8 +1,10 @@
-use std::fmt::{Debug, Display, Formatter};
 use crate::parser::parse_string_to_regex;
+use std::fmt::{Debug, Display, Formatter};
 
 pub const CLASS_ESCAPE_CHARS: &[char] = &['[', ']', '-', '\\'];
-pub const NON_CLASS_ESCAPE_CHARS: &[char] = &['[', ']', '(', ')', '{', '}', '?', '*', '+', '|', '\\', '.'];
+pub const NON_CLASS_ESCAPE_CHARS: &[char] = &[
+    '[', ']', '(', ')', '{', '}', '?', '*', '+', '|', '\\', '.',
+];
 
 fn escape_regex_char(c: char, in_class: bool) -> String {
     let to_escape = if in_class {
@@ -31,7 +33,12 @@ impl Display for CharRange {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Single(c) => write!(f, "{}", escape_regex_char(*c, true)),
-            Self::Range(start, end) => write!(f, "{}-{}", escape_regex_char(*start, true), escape_regex_char(*end, true)),
+            Self::Range(start, end) => write!(
+                f,
+                "{}-{}",
+                escape_regex_char(*start, true),
+                escape_regex_char(*end, true)
+            ),
         }
     }
 }
@@ -67,7 +74,7 @@ impl Display for Count {
                 } else {
                     write!(f, "{{{min},{max}}}")
                 }
-            },
+            }
             Self::AtLeast(min) => {
                 if *min == 0 {
                     write!(f, "*")
@@ -76,7 +83,7 @@ impl Display for Count {
                 } else {
                     write!(f, "{{{min},}}")
                 }
-            },
+            }
         }
     }
 }
@@ -102,43 +109,41 @@ pub enum Regex {
 
 impl Display for Regex {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            Self::Empty => "∅".to_string(),
-            Self::Epsilon => "ε".to_string(),
-            Self::Literal(c) => escape_regex_char(*c, false),
-            Self::Concat(left, right) => format!("{left}{right}"),
-            Self::Or(left, right) => format!("({left}|{right})"),
-            Self::Class(ranges) => {
-                let ranges_str = ranges.iter().map(|range| range.to_string()).collect::<String>();
-                format!("[{ranges_str}]")
+        write!(
+            f,
+            "{}",
+            match self {
+                Self::Empty => "∅".to_string(),
+                Self::Epsilon => "ε".to_string(),
+                Self::Literal(c) => escape_regex_char(*c, false),
+                Self::Concat(left, right) => format!("{left}{right}"),
+                Self::Or(left, right) => format!("({left}|{right})"),
+                Self::Class(ranges) => {
+                    let ranges_str = ranges
+                        .iter()
+                        .map(|range| range.to_string())
+                        .collect::<String>();
+                    format!("[{ranges_str}]")
+                }
+                Self::Count(inner, quantifier) => {
+                    format!("({inner}){quantifier}")
+                }
             }
-            Self::Count(inner, quantifier) => {
-                format!("({inner}){quantifier}")
-            },
-        })
+        )
     }
 }
 
 impl Regex {
     pub fn star(&self) -> Self {
-        Self::Count(
-            Box::new(self.clone()),
-            Count::AtLeast(0),
-        )
+        Self::Count(Box::new(self.clone()), Count::AtLeast(0))
     }
 
     pub fn plus(&self) -> Self {
-        Self::Count(
-            Box::new(self.clone()),
-            Count::AtLeast(1),
-        )
+        Self::Count(Box::new(self.clone()), Count::AtLeast(1))
     }
 
     pub fn optional(&self) -> Self {
-        Self::Count(
-            Box::new(self.clone()),
-            Count::Range(0, 1),
-        )
+        Self::Count(Box::new(self.clone()), Count::Range(0, 1))
     }
 
     fn is_nullable_(&self) -> bool {
@@ -149,11 +154,9 @@ impl Regex {
             Self::Concat(left, right) => left.is_nullable_() && right.is_nullable_(),
             Self::Or(left, right) => left.is_nullable_() || right.is_nullable_(),
             Self::Class(_) => false,
-            Self::Count(_, quantifier) => {
-                match quantifier {
-                    Count::Exact(n) => *n == 0,
-                    Count::Range(min, _) | Count::AtLeast(min) => *min == 0,
-                }
+            Self::Count(_, quantifier) => match quantifier {
+                Count::Exact(n) => *n == 0,
+                Count::Range(min, _) | Count::AtLeast(min) => *min == 0,
             },
         }
     }
@@ -177,25 +180,17 @@ impl Regex {
                 } else {
                     Self::Empty
                 }
-            },
-            Self::Concat(left, right) => {
-                Self::Or(
-                    Box::new(Self::Concat(
-                        Box::new(left.derivative(c)),
-                        right.clone(),
-                    ).simplify()),
-                    Box::new(Self::Concat(
-                        Box::new(left.is_nullable()),
-                        Box::new(right.derivative(c)),
-                    ).simplify()),
-                )
-            },
+            }
+            Self::Concat(left, right) => Self::Or(
+                Box::new(Self::Concat(Box::new(left.derivative(c)), right.clone()).simplify()),
+                Box::new(
+                    Self::Concat(Box::new(left.is_nullable()), Box::new(right.derivative(c)))
+                        .simplify(),
+                ),
+            ),
             Self::Or(left, right) => {
-                Self::Or(
-                    Box::new(left.derivative(c)),
-                    Box::new(right.derivative(c)),
-                )
-            },
+                Self::Or(Box::new(left.derivative(c)), Box::new(right.derivative(c)))
+            }
             Self::Class(ranges) => {
                 for range in ranges {
                     if range.contains(c) {
@@ -203,11 +198,13 @@ impl Regex {
                     }
                 }
                 Self::Empty
-            },
+            }
             Self::Count(inner, count) => {
                 let new_count = match count {
                     Count::Exact(n) => Count::Exact(n.saturating_sub(1)),
-                    Count::Range(min, max) => Count::Range(min.saturating_sub(1), max.saturating_sub(1)),
+                    Count::Range(min, max) => {
+                        Count::Range(min.saturating_sub(1), max.saturating_sub(1))
+                    }
                     Count::AtLeast(min) => Count::AtLeast(min.saturating_sub(1)),
                 };
 
@@ -216,7 +213,8 @@ impl Regex {
                     Box::new(Self::Count(inner.clone(), new_count)),
                 )
             }
-        }.simplify()
+        }
+        .simplify()
     }
 
     /// Simplifies the regex.
@@ -242,11 +240,8 @@ impl Regex {
                     return left_simplified;
                 }
 
-                Self::Concat(
-                    Box::new(left_simplified),
-                    Box::new(right_simplified),
-                )
-            },
+                Self::Concat(Box::new(left_simplified), Box::new(right_simplified))
+            }
             Self::Or(left, right) => {
                 let left_simplified = left.simplify();
                 let right_simplified = right.simplify();
@@ -264,11 +259,8 @@ impl Regex {
                     return left_simplified;
                 }
 
-                Self::Or(
-                    Box::new(left_simplified),
-                    Box::new(right_simplified),
-                )
-            },
+                Self::Or(Box::new(left_simplified), Box::new(right_simplified))
+            }
             Self::Class(ranges) => {
                 let mut new_ranges = Vec::new();
                 let mut changed = false;
@@ -301,7 +293,7 @@ impl Regex {
                     CharRange::Range(start, _) => *start,
                 });
                 Self::Class(new_ranges)
-            },
+            }
             Self::Count(inner, count) => {
                 let inner_simplified = inner.simplify();
 
@@ -338,10 +330,8 @@ impl Regex {
                 // r{n,n} = r{n}
                 if let Count::Range(min, max) = count {
                     if min == max {
-                        return Self::Count(
-                            Box::new(inner_simplified),
-                            Count::Exact(*min),
-                        ).simplify();
+                        return Self::Count(Box::new(inner_simplified), Count::Exact(*min))
+                            .simplify();
                     }
                 }
 
@@ -355,7 +345,7 @@ impl Regex {
                 }
 
                 Self::Count(Box::new(inner_simplified), *count)
-            },
+            }
         }
     }
 
@@ -405,79 +395,55 @@ mod tests {
 
     #[test]
     fn test_derivative_concat_first_char() {
-        let regex = Regex::Concat(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('b'))
-        );
+        let regex = Regex::Concat(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('b')));
         assert_eq!(regex.derivative('a'), Regex::Literal('b'));
     }
 
     #[test]
     fn test_derivative_or_left_match() {
-        let regex = Regex::Or(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('b'))
-        );
+        let regex = Regex::Or(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('b')));
         assert_eq!(regex.derivative('a'), Regex::Epsilon);
     }
 
     #[test]
     fn test_derivative_or_right_match() {
-        let regex = Regex::Or(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('b'))
-        );
+        let regex = Regex::Or(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('b')));
         assert_eq!(regex.derivative('b'), Regex::Epsilon);
     }
 
     #[test]
     fn test_derivative_or_no_match() {
-        let regex = Regex::Or(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('b'))
-        );
+        let regex = Regex::Or(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('b')));
         assert_eq!(regex.derivative('c'), Regex::Empty);
     }
 
     #[test]
     fn test_derivative_class_match() {
-        let regex = Regex::Class(vec![
-            CharRange::Single('a'),
-            CharRange::Range('c', 'e')
-        ]);
+        let regex = Regex::Class(vec![CharRange::Single('a'), CharRange::Range('c', 'e')]);
         assert_eq!(regex.derivative('a'), Regex::Epsilon);
         assert_eq!(regex.derivative('d'), Regex::Epsilon);
     }
 
     #[test]
     fn test_derivative_class_no_match() {
-        let regex = Regex::Class(vec![
-            CharRange::Single('a'),
-            CharRange::Range('c', 'e')
-        ]);
+        let regex = Regex::Class(vec![CharRange::Single('a'), CharRange::Range('c', 'e')]);
         assert_eq!(regex.derivative('b'), Regex::Empty);
         assert_eq!(regex.derivative('f'), Regex::Empty);
     }
 
     #[test]
     fn test_derivative_count_match() {
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Range(2, 3),
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Range(2, 3));
         let result = regex.derivative('a');
-        assert_eq!(result, Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Range(1, 2),
-        ));
+        assert_eq!(
+            result,
+            Regex::Count(Box::new(Regex::Literal('a')), Count::Range(1, 2),)
+        );
     }
 
     #[test]
     fn test_derivative_count_no_match() {
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Range(2, 3)
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Range(2, 3));
         assert_eq!(regex.derivative('b'), Regex::Empty);
     }
 
@@ -487,33 +453,36 @@ mod tests {
         let regex = Regex::Concat(
             Box::new(Regex::Literal('a')),
             Box::new(Regex::Concat(
-                Box::new(Regex::Or(
-                    Box::new(Regex::Literal('b')),
-                    Box::new(Regex::Literal('c'))
-                ).star()),
-                Box::new(Regex::Literal('d'))
-            ))
+                Box::new(
+                    Regex::Or(Box::new(Regex::Literal('b')), Box::new(Regex::Literal('c'))).star(),
+                ),
+                Box::new(Regex::Literal('d')),
+            )),
         );
 
         // Take derivative with respect to 'a'
         let d1 = regex.derivative('a');
-        assert_eq!(d1, Regex::Concat(
-            Box::new(Regex::Or(
-                Box::new(Regex::Literal('b')),
-                Box::new(Regex::Literal('c'))
-            ).star()),
-            Box::new(Regex::Literal('d'))
-        ));
+        assert_eq!(
+            d1,
+            Regex::Concat(
+                Box::new(
+                    Regex::Or(Box::new(Regex::Literal('b')), Box::new(Regex::Literal('c'))).star()
+                ),
+                Box::new(Regex::Literal('d'))
+            )
+        );
 
         // Take derivative with respect to 'b'
         let d2 = d1.derivative('b');
-        assert_eq!(d2, Regex::Concat(
-            Box::new(Regex::Or(
-                Box::new(Regex::Literal('b')),
-                Box::new(Regex::Literal('c'))
-            ).star()),
-            Box::new(Regex::Literal('d'))
-        ));
+        assert_eq!(
+            d2,
+            Regex::Concat(
+                Box::new(
+                    Regex::Or(Box::new(Regex::Literal('b')), Box::new(Regex::Literal('c'))).star()
+                ),
+                Box::new(Regex::Literal('d'))
+            )
+        );
 
         // Take derivative with respect to 'd'
         let d3 = d2.derivative('d');
@@ -542,61 +511,40 @@ mod tests {
     #[test]
     fn test_simplify_concat_with_empty() {
         // r∅ = ∅
-        let regex = Regex::Concat(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Empty)
-        );
+        let regex = Regex::Concat(Box::new(Regex::Literal('a')), Box::new(Regex::Empty));
         assert_eq!(regex.simplify(), Regex::Empty);
 
         // ∅r = ∅
-        let regex = Regex::Concat(
-            Box::new(Regex::Empty),
-            Box::new(Regex::Literal('a'))
-        );
+        let regex = Regex::Concat(Box::new(Regex::Empty), Box::new(Regex::Literal('a')));
         assert_eq!(regex.simplify(), Regex::Empty);
     }
 
     #[test]
     fn test_simplify_concat_with_epsilon() {
         // rε = r
-        let regex = Regex::Concat(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Epsilon)
-        );
+        let regex = Regex::Concat(Box::new(Regex::Literal('a')), Box::new(Regex::Epsilon));
         assert_eq!(regex.simplify(), Regex::Literal('a'));
 
         // εr = r
-        let regex = Regex::Concat(
-            Box::new(Regex::Epsilon),
-            Box::new(Regex::Literal('a'))
-        );
+        let regex = Regex::Concat(Box::new(Regex::Epsilon), Box::new(Regex::Literal('a')));
         assert_eq!(regex.simplify(), Regex::Literal('a'));
     }
 
     #[test]
     fn test_simplify_or_with_empty() {
         // r ∪ ∅ = r
-        let regex = Regex::Or(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Empty)
-        );
+        let regex = Regex::Or(Box::new(Regex::Literal('a')), Box::new(Regex::Empty));
         assert_eq!(regex.simplify(), Regex::Literal('a'));
 
         // ∅ ∪ r = r
-        let regex = Regex::Or(
-            Box::new(Regex::Empty),
-            Box::new(Regex::Literal('a'))
-        );
+        let regex = Regex::Or(Box::new(Regex::Empty), Box::new(Regex::Literal('a')));
         assert_eq!(regex.simplify(), Regex::Literal('a'));
     }
 
     #[test]
     fn test_simplify_or_with_same() {
         // r ∪ r = r
-        let regex = Regex::Or(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('a'))
-        );
+        let regex = Regex::Or(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('a')));
         assert_eq!(regex.simplify(), Regex::Literal('a'));
     }
 
@@ -637,81 +585,57 @@ mod tests {
         let regex = Regex::Class(vec![
             CharRange::Single('c'),
             CharRange::Single('a'),
-            CharRange::Range('d', 'f')
+            CharRange::Range('d', 'f'),
         ]);
-        assert_eq!(regex.simplify(), Regex::Class(vec![
-            CharRange::Single('a'),
-            CharRange::Single('c'),
-            CharRange::Range('d', 'f')
-        ]));
+        assert_eq!(
+            regex.simplify(),
+            Regex::Class(vec![
+                CharRange::Single('a'),
+                CharRange::Single('c'),
+                CharRange::Range('d', 'f')
+            ])
+        );
     }
 
     #[test]
     fn test_simplify_count() {
         // ∅{n} = ∅
-        let regex = Regex::Count(
-            Box::new(Regex::Empty),
-            Count::Exact(2),
-        );
+        let regex = Regex::Count(Box::new(Regex::Empty), Count::Exact(2));
         assert_eq!(regex.simplify(), Regex::Empty);
 
         // ∅{n,m} = ∅
-        let regex = Regex::Count(
-            Box::new(Regex::Empty),
-            Count::Range(2, 3)
-        );
+        let regex = Regex::Count(Box::new(Regex::Empty), Count::Range(2, 3));
         assert_eq!(regex.simplify(), Regex::Empty);
 
         // ∅{n,} = ∅
-        let regex = Regex::Count(
-            Box::new(Regex::Empty),
-            Count::AtLeast(2)
-        );
+        let regex = Regex::Count(Box::new(Regex::Empty), Count::AtLeast(2));
         assert_eq!(regex.simplify(), Regex::Empty);
 
         // ε{n} = ε
-        let regex = Regex::Count(
-            Box::new(Regex::Epsilon),
-            Count::Exact(2)
-        );
+        let regex = Regex::Count(Box::new(Regex::Epsilon), Count::Exact(2));
         assert_eq!(regex.simplify(), Regex::Epsilon);
 
         // ε{n,m} = ε
-        let regex = Regex::Count(
-            Box::new(Regex::Epsilon),
-            Count::Range(2, 3)
-        );
+        let regex = Regex::Count(Box::new(Regex::Epsilon), Count::Range(2, 3));
         assert_eq!(regex.simplify(), Regex::Epsilon);
 
         // ε{n,} = ε
-        let regex = Regex::Count(
-            Box::new(Regex::Epsilon),
-            Count::AtLeast(2)
-        );
+        let regex = Regex::Count(Box::new(Regex::Epsilon), Count::AtLeast(2));
         assert_eq!(regex.simplify(), Regex::Epsilon);
 
         // r{n,n} = r{n}
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Range(2, 2),
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Range(2, 2));
+        assert_eq!(
+            regex.simplify(),
+            Regex::Count(Box::new(Regex::Literal('a')), Count::Exact(2),)
         );
-        assert_eq!(regex.simplify(), Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Exact(2),
-        ));
 
         // r{0} = ε
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Exact(0),
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Exact(0));
         assert_eq!(regex.simplify(), Regex::Epsilon);
 
         // r{1} = r
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Exact(1),
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Exact(1));
         assert_eq!(regex.simplify(), Regex::Literal('a'));
     }
 
@@ -721,23 +645,26 @@ mod tests {
         let regex = Regex::Concat(
             Box::new(Regex::Or(
                 Box::new(Regex::Literal('a')),
-                Box::new(Regex::Empty)
+                Box::new(Regex::Empty),
             )),
             Box::new(Regex::Or(
                 Box::new(Regex::Epsilon),
-                Box::new(Regex::Literal('b').star())
-            ))
+                Box::new(Regex::Literal('b').star()),
+            )),
         );
 
         // Should simplify to a(ε|b*) which further simplifies to a
         let simplified = regex.simplify();
-        assert_eq!(simplified, Regex::Concat(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Or(
-                Box::new(Regex::Epsilon),
-                Box::new(Regex::Literal('b').star())
-            ))
-        ));
+        assert_eq!(
+            simplified,
+            Regex::Concat(
+                Box::new(Regex::Literal('a')),
+                Box::new(Regex::Or(
+                    Box::new(Regex::Epsilon),
+                    Box::new(Regex::Literal('b').star())
+                ))
+            )
+        );
     }
 
     // matches tests
@@ -750,10 +677,7 @@ mod tests {
 
     #[test]
     fn test_matches_concat() {
-        let regex = Regex::Concat(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('b'))
-        );
+        let regex = Regex::Concat(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('b')));
         assert!(regex.matches("ab"));
         assert!(!regex.matches("a"));
         assert!(!regex.matches("b"));
@@ -761,10 +685,7 @@ mod tests {
 
     #[test]
     fn test_matches_or() {
-        let regex = Regex::Or(
-            Box::new(Regex::Literal('a')),
-            Box::new(Regex::Literal('b'))
-        );
+        let regex = Regex::Or(Box::new(Regex::Literal('a')), Box::new(Regex::Literal('b')));
         assert!(regex.matches("a"));
         assert!(regex.matches("b"));
         assert!(!regex.matches("c"));
@@ -794,10 +715,7 @@ mod tests {
 
     #[test]
     fn test_matches_count_range() {
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Range(2, 3)
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Range(2, 3));
         assert!(!regex.matches(""));
         assert!(!regex.matches("a"));
         assert!(regex.matches("aa"));
@@ -807,10 +725,7 @@ mod tests {
 
     #[test]
     fn test_matches_count_single() {
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Exact(2)
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Exact(2));
 
         assert!(!regex.matches(""));
         assert!(!regex.matches("a"));
@@ -828,22 +743,13 @@ mod tests {
 
     #[test]
     fn test_count_print() {
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Range(2, 3)
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Range(2, 3));
         assert_eq!(regex.to_string(), "(a){2,3}");
 
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::Exact(2)
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::Exact(2));
         assert_eq!(regex.to_string(), "(a){2}");
 
-        let regex = Regex::Count(
-            Box::new(Regex::Literal('a')),
-            Count::AtLeast(2)
-        );
+        let regex = Regex::Count(Box::new(Regex::Literal('a')), Count::AtLeast(2));
         assert_eq!(regex.to_string(), "(a){2,}");
 
         let regex = Regex::Literal('a').star();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,19 +1,55 @@
-#![warn(unused_crate_dependencies)]
-
-//! *rzozowski* (ruh-zov-ski) is a Rust crate for reasoning about regular expressions in terms of Brzozowski derivatives.
+#![deny(
+    unsafe_code,
+    clippy::undocumented_unsafe_blocks,
+    clippy::multiple_unsafe_ops_per_block,
+)]
 
 #![warn(
-    clippy::suspicious,
-    clippy::complexity,
-    clippy::perf,
-    clippy::style,
-    clippy::uninlined_format_args,
-    clippy::trivially_copy_pass_by_ref,
-    clippy::unnecessary_join,
-    clippy::unnecessary_wraps,
+    clippy::cognitive_complexity,
+    clippy::dbg_macro,
+    clippy::debug_assert_with_mut_call,
+    clippy::doc_link_with_quotes,
+    clippy::doc_markdown,
+    clippy::empty_line_after_outer_attr,
+    clippy::empty_structs_with_brackets,
     clippy::format_push_string,
-    clippy::non_std_lazy_statics
+    clippy::missing_const_for_fn,
+/*
+ * The following lints (especially the first one) require a lot of documentation
+ * to be written before being globally enabled, which is why they are left disabled
+ * until the documentation has been written in a separate PR.
+    clippy::missing_docs_in_private_items,
+    clippy::missing_errors_doc,
+    clippy::missing_panics_doc,
+*/
+    clippy::non_std_lazy_statics,
+    clippy::option_if_let_else,
+    clippy::print_stderr,
+    clippy::print_stdout,
+    clippy::semicolon_if_nothing_returned,
+    clippy::similar_names,
+    clippy::suspicious_operation_groupings,
+    clippy::trivially_copy_pass_by_ref,
+    clippy::uninlined_format_args,
+    clippy::unnecessary_join,
+    clippy::unnecessary_safety_comment,
+    clippy::unnecessary_safety_doc,
+    clippy::unnecessary_wraps,
+    clippy::unseparated_literal_suffix,
+    clippy::unused_self,
+    clippy::used_underscore_binding,
+    clippy::useless_let_if_seq,
+    clippy::wildcard_dependencies,
+    clippy::wildcard_imports,
+    keyword_idents,
+    missing_debug_implementations,
+    noop_method_call,
+    unused_crate_dependencies,
+    unused_extern_crates,
+    unused_import_braces,
 )]
+
+//! *rzozowski* (ruh-zov-ski) is a Rust crate for reasoning about regular expressions in terms of Brzozowski derivatives.
 
 mod derivatives;
 mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 #![deny(
     unsafe_code,
     clippy::undocumented_unsafe_blocks,
-    clippy::multiple_unsafe_ops_per_block,
+    clippy::multiple_unsafe_ops_per_block
 )]
-
 #![warn(
     clippy::cognitive_complexity,
     clippy::dbg_macro,
@@ -54,4 +53,4 @@
 mod derivatives;
 mod parser;
 
-pub use derivatives::{Regex, Count, CharRange};
+pub use derivatives::{CharRange, Count, Regex};

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -394,6 +394,10 @@ pub fn parse_string_to_regex(input: &str) -> Result<Regex, String> {
 }
 
 mod tests {
+    // Not quite sure why this triggers here, possibly the include is too "broad"
+    // The code fails to compile without the use statement, yet clippy isn't happy about it being
+    // there.
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -246,7 +246,7 @@ where
         })
 }
 
-/// Parses a Count::Exact (e.g., `{3}`).
+/// Parses a `Count::Exact` (e.g., `{3}`).
 fn parse_count_exact<'a, I>() -> impl Parser<'a, I, Count, extra::Err<Rich<'a, Token>>>
 where
     I: ValueInput<'a, Token = Token, Span = SimpleSpan>,
@@ -257,7 +257,7 @@ where
         .map(Count::Exact)
 }
 
-/// Parses a Count::Range (e.g., `{3,5}`).
+/// Parses a `Count::Range` (e.g., `{3,5}`).
 fn parse_count_range<'a, I>() -> impl Parser<'a, I, Count, extra::Err<Rich<'a, Token>>>
 where
     I: ValueInput<'a, Token = Token, Span = SimpleSpan>,
@@ -270,7 +270,7 @@ where
         .map(|(min, max)| Count::Range(min, max))
 }
 
-/// Parses a Count::AtLeast (e.g., `{3,}`).
+/// Parses a `Count::AtLeast` (e.g., `{3,}`).
 fn parse_count_at_least<'a, I>() -> impl Parser<'a, I, Count, extra::Err<Rich<'a, Token>>>
 where
     I: ValueInput<'a, Token = Token, Span = SimpleSpan>,

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -46,7 +46,7 @@ impl fmt::Display for Token {
 }
 
 impl Token {
-    pub fn as_char(&self) -> char {
+    pub const fn as_char(&self) -> char {
         match self {
             Self::Literal(c) => *c,
             Self::OpenParen => '(',

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -70,6 +70,10 @@ impl Token {
 }
 
 mod tests {
+    // Not quite sure why this triggers here, possibly the include is too "broad"
+    // The code fails to compile without the use statement, yet clippy isn't happy about it being
+    // there.
+    #[allow(unused_imports)]
     use super::*;
 
     #[test]

--- a/src/parser/lexer.rs
+++ b/src/parser/lexer.rs
@@ -1,5 +1,5 @@
-use std::fmt;
 use logos::Logos;
+use std::fmt;
 
 #[derive(Logos, Debug, PartialEq, Eq, Clone)]
 pub enum Token {


### PR DESCRIPTION
(Sorry about the noise with multiple PRs for the lints, but I was seemingly rather tired last night when I submitted them, as I explicitly enabled a bunch of default lints that `cargo clippy` always checks for.)

---

In this PR I propose a clean-up of all my previously submitted lints.
* Removes enabled-by-default lints.
* Add additional lints considered useful by other projects.
* Fix some markdown-related nitpicks in doc-comments.
* Mark functions as const wherever possible.

### Items up for discussion:
* I added a default deny of unsafe code and missing safety documentation despite this project not having any unsafe code currently.
This seems to be a generally sane default, as it enforces a case-by-case approval of any unsafe code, along with mandatory safety comments.

* I've furthermore left three lints disabled with a comment explaining why, as enabling them will in turn create a bunch of documentation-related warnings.

@rockysnow7:
If you feel that the above is desirable I'll update the PR to enable the documentation-related lints, and also write a draft for the documentation itself.

We can then review those changes further before finally merging this PR.